### PR TITLE
Update MacPorts and macOS references

### DIFF
--- a/source/jp2a/index.html
+++ b/source/jp2a/index.html
@@ -96,7 +96,7 @@ make install-lib   # simply make install is not good enough for jp2a
 
 <h2>Mac OS X</h2>
 <div class="text">
-jp2a is now part of <a href="http://www.darwinports.org/">DarwinPorts</a>, so if you do a
+jp2a is part of <a href="https://www.macports.org">MacPorts</a>, so if you do a
 
 <pre>
 sudo port install jp2a

--- a/source/jp2a/index.html
+++ b/source/jp2a/index.html
@@ -94,7 +94,7 @@ make install-lib   # simply make install is not good enough for jp2a
 </pre>
 </div>
 
-<h2>Mac OS X</h2>
+<h2>macOS</h2>
 <div class="text">
 jp2a is part of <a href="https://www.macports.org">MacPorts</a>, so if you do a
 


### PR DESCRIPTION
This PR replaces the outdated DarwinPorts name with the new name MacPorts, and replaces the outdated Mac OS X name with the new name macOS.